### PR TITLE
Allow searches for ICD19 code stem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>share.broker.rest</artifactId>
-    <version>8.4.3-SNAPSHOT</version>
+    <version>8.5.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <name>Searchbroker</name>

--- a/src/main/resources/de/samply/share/broker/utils/cql/samply_cql_config.xml
+++ b/src/main/resources/de/samply/share/broker/utils/cql/samply_cql_config.xml
@@ -690,13 +690,13 @@
     </codesystem>
     <entityType>
       <atomicExpression>
-      <atomicCqlExpression>( (not Matches(''{2}'',''\\w\\d+'') and exists
+      <atomicCqlExpression>( (not (Matches(''{2}'',''\\w\\d+'') and exists
           from [Condition] C
           where exists
           from C.code.coding CD
-          where StartsWith(CD.code,''{2}'') and (CD.system = ''http://hl7.org/fhir/sid/icd-10'' or CD.system = ''http://fhir.de/CodeSystem/dimdi/icd-10-gm0'') )
+          where StartsWith(CD.code,''{2}'') and (CD.system = ''http://hl7.org/fhir/sid/icd-10'' or CD.system = ''http://fhir.de/CodeSystem/dimdi/icd-10-gm0'')))
           and not exists([Condition: Code ''{2}'' from icd10]) and not
-          exists([Condition: Code ''{2}'' from icd10gm]))
+          exists([Condition: Code ''{2}'' from icd10gm]) )
         </atomicCqlExpression>
         <operator>&lt;&gt;</operator>
       </atomicExpression>
@@ -705,9 +705,9 @@
           from [Condition] C
           where exists
           from C.code.coding CD
-          where StartsWith(CD.code,''{2}'') and (CD.system = ''http://hl7.org/fhir/sid/icd-10'' or CD.system = ''http://fhir.de/CodeSystem/dimdi/icd-10-gm0'') )
+          where StartsWith(CD.code,''{2}'') and (CD.system = ''http://hl7.org/fhir/sid/icd-10'' or CD.system = ''http://fhir.de/CodeSystem/dimdi/icd-10-gm0''))
           or exists([Condition: Code ''{2}'' from icd10]) or exists([Condition:
-          Code ''{2}'' from icd10gm]))
+          Code ''{2}'' from icd10gm]) )
         </atomicCqlExpression>
         <operator>DEFAULT</operator>
       </atomicExpression>
@@ -716,13 +716,21 @@
     </entityType>
     <entityType>
       <atomicExpression>
-        <atomicCqlExpression>(not exists([Patient -&gt; Condition: Code ''{2}'' from icd10]) and not
-          exists([Patient -&gt; Condition: Code ''{2}'' from icd10gm]))
+        <atomicCqlExpression>( (not (Matches(''{2}'',''\\w\\d+'') and
+          exists from [Patient -> Condition] C
+          where exists from C.code.coding CD
+          where StartsWith(CD.code,''{2}'') and (CD.system = ''http://hl7.org/fhir/sid/icd-10'' or CD.system = ''http://fhir.de/CodeSystem/dimdi/icd-10-gm0'')))
+          and not exists([Patient -&gt; Condition: Code ''{2}'' from icd10]) and not
+          exists([Patient -&gt; Condition: Code ''{2}'' from icd10gm]) )
         </atomicCqlExpression>
         <operator>&lt;&gt;</operator>
       </atomicExpression>
       <atomicExpression>
-        <atomicCqlExpression>(exists([Patient -&gt; Condition: Code ''{2}'' from icd10]) or
+        <atomicCqlExpression>( (Matches(''{2}'',''\\w\\d+'') and
+          exists from [Patient -> Condition] C
+          where exists from C.code.coding CD
+          where StartsWith(CD.code,''{2}'') and (CD.system = ''http://hl7.org/fhir/sid/icd-10'' or CD.system = ''http://fhir.de/CodeSystem/dimdi/icd-10-gm0''))
+          or exists([Patient -&gt; Condition: Code ''{2}'' from icd10]) or
           exists([Patient -&gt; Condition: Code ''{2}'' from icd10gm]))
         </atomicCqlExpression>
         <operator>DEFAULT</operator>

--- a/src/main/resources/de/samply/share/broker/utils/cql/samply_cql_config.xml
+++ b/src/main/resources/de/samply/share/broker/utils/cql/samply_cql_config.xml
@@ -690,13 +690,23 @@
     </codesystem>
     <entityType>
       <atomicExpression>
-        <atomicCqlExpression>(not exists([Condition: Code ''{2}'' from icd10]) and not
+      <atomicCqlExpression>( (not Matches(''{2}'',''\\w\\d+'') and exists
+          from [Condition] C
+          where exists
+          from C.code.coding CD
+          where StartsWith(CD.code,''{2}'') and (CD.system = ''http://hl7.org/fhir/sid/icd-10'' or CD.system = ''http://fhir.de/CodeSystem/dimdi/icd-10-gm0'') )
+          and not exists([Condition: Code ''{2}'' from icd10]) and not
           exists([Condition: Code ''{2}'' from icd10gm]))
         </atomicCqlExpression>
         <operator>&lt;&gt;</operator>
       </atomicExpression>
       <atomicExpression>
-        <atomicCqlExpression>(exists([Condition: Code ''{2}'' from icd10]) or exists([Condition:
+        <atomicCqlExpression>( (Matches(''{2}'',''\\w\\d+'') and exists
+          from [Condition] C
+          where exists
+          from C.code.coding CD
+          where StartsWith(CD.code,''{2}'') and (CD.system = ''http://hl7.org/fhir/sid/icd-10'' or CD.system = ''http://fhir.de/CodeSystem/dimdi/icd-10-gm0'') )
+          or exists([Condition: Code ''{2}'' from icd10]) or exists([Condition:
           Code ''{2}'' from icd10gm]))
         </atomicCqlExpression>
         <operator>DEFAULT</operator>

--- a/src/main/resources/de/samply/share/broker/utils/cql/samply_cql_config.xml
+++ b/src/main/resources/de/samply/share/broker/utils/cql/samply_cql_config.xml
@@ -717,7 +717,7 @@
     <entityType>
       <atomicExpression>
         <atomicCqlExpression>( (not (Matches(''{2}'',''\\w\\d+'') and
-          exists from [Patient -> Condition] C
+          exists from [Patient -&gt; Condition] C
           where exists from C.code.coding CD
           where StartsWith(CD.code,''{2}'') and (CD.system = ''http://hl7.org/fhir/sid/icd-10'' or CD.system = ''http://fhir.de/CodeSystem/dimdi/icd-10-gm0'')))
           and not exists([Patient -&gt; Condition: Code ''{2}'' from icd10]) and not
@@ -727,7 +727,7 @@
       </atomicExpression>
       <atomicExpression>
         <atomicCqlExpression>( (Matches(''{2}'',''\\w\\d+'') and
-          exists from [Patient -> Condition] C
+          exists from [Patient -&gt; Condition] C
           where exists from C.code.coding CD
           where StartsWith(CD.code,''{2}'') and (CD.system = ''http://hl7.org/fhir/sid/icd-10'' or CD.system = ''http://fhir.de/CodeSystem/dimdi/icd-10-gm0''))
           or exists([Patient -&gt; Condition: Code ''{2}'' from icd10]) or


### PR DESCRIPTION
The Locator search GUI has a built in autocompletion, that allows you
to enter the stem part of an ICD10 code (E.g. "O10"). You can then
select a more exact code (e.g. "O10.9").

But what if you want all codes associated with the stem (e.g. "O10.1",
"O10.2", ... "O10.9")? To do this, you would need to build a query with
all of these codes, a weildly and time-consuming affair, which is
naturally also error-prone.

If a user deliberately sends an ICD10 code stem, the existing code will
return nothing, because it only works with exact matches.

Hence this patch. It has additional CQL that first checks for the case
that the user has sent an ICD10 code stem, such as "O10". If so, the
stem is checked against all codes, and any matches are further checked
to make sure that they are also ICD10.

If the search term does not fit the pattern for an ICD10 stem, it is
passed on to the original CQL, which should be more efficient, because
it does full-string matches rather than partial matches.

**What's in the PR**
* ...

**How to test manually**
* ...
